### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -12,7 +12,7 @@ module "cloudtrail_bucket" {
 module "account_map" {
   source    = "cloudposse/stack-config/yaml//modules/remote-state"
   version   = "1.8.0"
-  component = "account-map"
+  component = var.account_map_component_name
 
   tenant      = module.iam_roles.global_tenant_name
   environment = module.iam_roles.global_environment_name

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -109,3 +109,9 @@ variable "cloudtrail_bucket_component_name" {
   description = "The name of the CloudTrail bucket component"
   default     = "cloudtrail-bucket"
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variables `account_map_component_name`.
* Variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.