### PR TITLE
feat: Add static partition date variable to prevent continuous drift

### DIFF
--- a/src/cloudtrail.tf
+++ b/src/cloudtrail.tf
@@ -7,8 +7,8 @@ locals {
   cloudtrail_table_name = "%s_cloudtrail_logs"
 
   # s3://cloudtrail_bucket_name/AWSLogs/organization_id/Account_ID/CloudTrail/
-  organization_id         = module.account_map.outputs.org.id
-  cloudtrail_s3_bucket_id = module.cloudtrail_bucket[0].outputs.cloudtrail_bucket_id
+  organization_id         = local.cloudtrail_enabled ? module.account_map.outputs.org.id : ""
+  cloudtrail_s3_bucket_id = local.cloudtrail_enabled ? module.cloudtrail_bucket[0].outputs.cloudtrail_bucket_id : ""
   cloudtrail_s3_location  = "s3://${local.cloudtrail_s3_bucket_id}/AWSLogs/${local.organization_id}/%s/CloudTrail/"
 
   cloudtrail_query_create_table = <<EOT
@@ -73,12 +73,12 @@ LOCATION '${local.cloudtrail_s3_location}'
 EOT
 
 
-  account_name  = lookup(module.this.descriptors, "account_name", module.this.stage)
-  account_id    = module.account_map.outputs.full_account_map[local.account_name]
-  timestamp     = timestamp()
-  current_year  = formatdate("YYYY", local.timestamp)
-  current_month = formatdate("MM", local.timestamp)
-  current_day   = formatdate("DD", local.timestamp)
+  account_name        = lookup(module.this.descriptors, "account_name", module.this.stage)
+  account_id          = module.account_map.outputs.full_account_map[local.account_name]
+  partition_timestamp = var.cloudtrail_query_alter_tables_partition_date != null ? "${var.cloudtrail_query_alter_tables_partition_date}T00:00:00Z" : timestamp()
+  current_year        = formatdate("YYYY", local.partition_timestamp)
+  current_month       = formatdate("MM", local.partition_timestamp)
+  current_day         = formatdate("DD", local.partition_timestamp)
 
   cloudtrail_query_alter_table = <<EOT
 ALTER TABLE ${local.cloudtrail_table_name} ADD

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -115,3 +115,14 @@ variable "account_map_component_name" {
   description = "The name of the account-map component"
   default     = "account-map"
 }
+
+variable "cloudtrail_query_alter_tables_partition_date" {
+  type        = string
+  description = "Static partition date for CloudTrail ALTER TABLE queries (format: YYYY-MM-DD). If set, prevents continuous drift by locking the template to this date. If null, uses current date."
+  default     = null
+
+  validation {
+    condition     = var.cloudtrail_query_alter_tables_partition_date == null || can(regex("^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$", var.cloudtrail_query_alter_tables_partition_date))
+    error_message = "The cloudtrail_query_alter_tables_partition_date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `cloudtrail_query_alter_tables_partition_date` variable to allow setting a static date for CloudTrail ALTER TABLE partition queries
- Fixes error when component is disabled (module outputs accessed when count is 0)

## Problem

The CloudTrail ALTER TABLE partition queries use `timestamp()` which causes the named queries to be replaced on **every** `plan`/`apply` due to the changing timestamp value. This creates continuous drift that clutters plans and causes unnecessary resource replacements.

## Solution

Add a new variable that allows setting a static date (format: `YYYY-MM-DD`) to lock the template. When `null` (default), uses current date for backwards compatibility.

## Usage

```yaml
vars:
  cloudtrail_query_alter_tables_partition_date: "2026-04-01"
```

## Test plan

- [x] Verify plan shows no changes when partition date is set
- [x] Verify backwards compatibility when variable is null
- [x] Verify component works when disabled (enabled: false)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to pin the partition date used for CloudTrail query generation (YYYY-MM-DD); defaults to current date when not set and validated for correct format.

* **Improvements**
  * More robust partition timestamp handling and date derivation for queries.
  * Safer behavior when CloudTrail is disabled: related identifiers now resolve to empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->